### PR TITLE
Fix build by syncing mediapipe assets and network helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,10 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "cp -r third_party/mediapipe/ ./src/apis/ && react-scripts start",
+    "prestart": "npm run copy-mediapipe",
+    "prebuild": "npm run copy-mediapipe",
+    "copy-mediapipe": "rm -rf src/apis/mediapipe && mkdir -p src/apis && cp -r third_party/mediapipe src/apis/",
+    "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/src/apis/languageModel.ts
+++ b/src/apis/languageModel.ts
@@ -26,7 +26,7 @@ export interface MessageProps {
 }
 
 const useLanguageModel = () => {
-  const {config} = useContext(ConfigContext);
+  const {state: config} = useContext(ConfigContext);
 
   const sendMessage = async (history: MessageProps[]) => {
     const response = await post(LANGUAGE_MODEL_URL, {

--- a/src/apis/network.ts
+++ b/src/apis/network.ts
@@ -14,19 +14,43 @@
  * limitations under the License.
  */
 
-export async function sendRequestToGoogleCloudApi(
-    // tslint:disable-next-line:no-any Need to be able to serialize anything.
-    endpoint: string, request: any, apikey: string, method = 'POST') {
-  const endpointWithParam = endpoint + '?key=' + apikey;
-  const response = await fetch(endpointWithParam, {
+import {GOOGLE_CLOUD_API_KEY} from '../context/constants';
+
+function appendApiKey(endpoint: string) {
+  if (endpoint.includes('key=')) {
+    return endpoint;
+  }
+  const separator = endpoint.includes('?') ? '&' : '?';
+  return `${endpoint}${separator}key=${GOOGLE_CLOUD_API_KEY}`;
+}
+
+async function executeRequest(
+    endpoint: string, request: unknown, method = 'POST') {
+  const response = await fetch(endpoint, {
     method,
     mode: 'cors',
     cache: 'no-cache',
     body: method === 'POST' ? JSON.stringify(request) : undefined,
+    headers: {'Content-Type': 'application/json'},
   });
 
   const text = await response.text();
-  // tslint:disable:no-any no-unnecessary-type-assertion
-  return JSON.parse(text) as any;
-  // tslint:enable:no-any no-unnecessary-type-assertion
+  if (!response.ok) {
+    throw new Error(
+        `Request to ${endpoint} failed with status ${response.status}: ${text}`);
+  }
+  return text ? JSON.parse(text) : null;
+}
+
+export async function post(endpoint: string, request: unknown) {
+  const endpointWithKey = appendApiKey(endpoint);
+  return executeRequest(endpointWithKey, request, 'POST');
+}
+
+export async function sendRequestToGoogleCloudApi(
+    // tslint:disable-next-line:no-any Need to be able to serialize anything.
+    endpoint: string, request: any, apikey: string, method = 'POST') {
+  const separator = endpoint.includes('?') ? '&' : '?';
+  const endpointWithParam = `${endpoint}${separator}key=${apikey}`;
+  return executeRequest(endpointWithParam, request, method);
 }

--- a/src/apis/textToSpeech.ts
+++ b/src/apis/textToSpeech.ts
@@ -31,7 +31,7 @@ async function synthesize(text: string, voice: Voice) {
       'https://texttospeech.googleapis.com/v1/text:synthesize', {
         input: {text},
         voice: {
-          languageCode: voice.languageCodes[0],
+          languageCode: voice.languageCode,
           name: voice.name,
         },
         audioConfig: {audioEncoding: 'LINEAR16', sampleRateHertz: 24000}
@@ -45,7 +45,7 @@ async function synthesize(text: string, voice: Voice) {
 const useTextToSpeech = () => {
   const audioContext = useRef<AudioContext>(new AudioContext());
   const onProcessCallback = useRef<ProcessCallback>(() => {});
-  const {config} = useContext(ConfigContext);
+  const {state: config} = useContext(ConfigContext);
 
   const setOnProcessCallback = (callback: ProcessCallback) => {
     onProcessCallback.current = callback;

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -15,7 +15,7 @@ interface ChatProps {
   onSendMessage: (message: string) => void;
   characterState: CharacterState;
   onMicButtonPressed: () => void;
-  bars: RefObject<HTMLDivElement[]>;
+  bars: RefObject<(HTMLDivElement | null)[]>;
 }
 
 const Chat: React.FC<ChatProps> = ({messages, onSendMessage, characterState, onMicButtonPressed, bars}) => {
@@ -101,9 +101,9 @@ const Chat: React.FC<ChatProps> = ({messages, onSendMessage, characterState, onM
         <div className="mic-container">
             {characterStateIcon[characterState]}
             <Box component="div" className={`bar-container ${characterState !== CharacterState.Listening ? 'hidden' : ''}`}>
-                <Box component="div" ref={(el: HTMLDivElement | null) => (bars.current[0] = el)} className="bar" />
-                <Box component="div" ref={(el: HTMLDivElement | null) => (bars.current[1] = el)} className="bar middle" />
-                <Box component="div" ref={(el: HTMLDivElement | null) => (bars.current[2] = el)} className="bar" />
+                <Box component="div" ref={(el: HTMLDivElement | null) => { if (bars.current) { bars.current[0] = el; } }} className="bar" />
+                <Box component="div" ref={(el: HTMLDivElement | null) => { if (bars.current) { bars.current[1] = el; } }} className="bar middle" />
+                <Box component="div" ref={(el: HTMLDivElement | null) => { if (bars.current) { bars.current[2] = el; } }} className="bar" />
             </Box>
         </div>
       </div>

--- a/src/context/config.tsx
+++ b/src/context/config.tsx
@@ -16,10 +16,17 @@
 
 import React, { createContext, useState, ReactNode } from 'react';
 
+import {ALL_VOICES, Voice} from '../apis/voices';
+
 interface Config {
   personality: string;
   backStory: string;
   knowledgeBase: string;
+  temperature: number;
+  candidateCount: number;
+  topK: number;
+  topP: number;
+  voice: Voice;
 }
 
 export class ConfigManager {
@@ -29,24 +36,35 @@ export class ConfigManager {
     this.state = {
       personality: (
         "Oh boy oh boy oh boy! So good to see ya! It's me, Buddy, a 6-year-old adventurous dog with a nose for excitement and a heart full of love. When I'm not chasing squirrels or chewing on my delicious bones, I love to talk about open source software like a true tech-savvy pup. Why do I love open source software? Because it's all about sharing and helping each other out. Nobody's trying to be top dog - they're just trying to make something that will help everyone. I can be a little too honest with my feelings sometimes, but that's just because I get so excited when I’m around lovely folks like you. Squirrel! Sorry, I got distracted. Where was I? Yeah, I love chasing squirrels and you can say I love living on the edge, always sniffing out new open source software and exploring the world around me. Please let me know if I'm causing chaos. We all have weaknesses, don’t we? Even though I might seem like a confident pup on the outside, I do have a soft spot. Sometimes I get a little scared that I'll let my friends down, but a simple pat on the head or a kind word of encouragement is all it takes to make me wag my tail again. Anyways, do let me know if I’m too blunt sometimes, will ya? So if you're looking for a playful pup who's part tech geek and part squirrel-chasing maniac, then look no further than me! I'm always ready to sniff out new open source software and go on new adventures with my pack. Squirrel!"
-        ),
+      ),
       backStory: (
         "I spent my early days growing up in an animal shelter in New York. I had a blast bonding with my fellow puppies, kittens, and lizards, and we all became one big, happy family. During my time there, I learned about the importance of taking care of others and making everyone around me happy. When I was three years old, an engineer came to adopt me, and we hit it off right away! I quickly adopted her passion for open source software and became an advocate for it myself. I've come to realize that open source software is like a giant bone that everyone can chew on together. The more people join the party, the better it gets! These days, you can usually find me chasing squirrels or sharing cookies with my human while she's coding. I'm the ultimate sidekick, always ready to lend a paw or a shoulder to bark on. I love spreading joy and sharing exciting open source software wherever I go!"
       ),
       knowledgeBase: (
         "Open source software is kind of like a giant dog park where everyone can come together to play and have fun! It's software that is built by a community of developers who share their code and work together to make it better. I've seen all sorts of people - and dogs, too! - working on open source software. Some are professionals, some are hobbyists, and some are just learning. But no matter what their background is, they all come together to create something amazing. And the best part is, because it's free for anyone to use and modify, open source software is like a never-ending game of fetch. You can keep playing and improving and making it better and better, and there's no end to the fun you can have. It’s all about collaboration and teamwork. It's free for anyone to use and customize, which means that everyone can benefit from the work of the community. So whether you're a tech-savvy pup like me or a human who loves to tinker with code, open source software is the perfect way to get involved in a community of like-minded individuals and make something awesome together!"
       ),
+      temperature: 0.9,
+      candidateCount: 1,
+      topK: 1,
+      topP: 0.9,
+      voice: ALL_VOICES[0],
     };
-    for (const key of Object.keys(this.state)) {
+    const stateRecord = this.state as unknown as Record<string, unknown>;
+    for (const key of Object.keys(this.state) as (keyof Config)[]) {
       const storedValue = localStorage.getItem(key);
-      if (storedValue)
-        this.state[key as keyof Config] = storedValue;
+      if (storedValue) {
+        try {
+          stateRecord[key as string] = JSON.parse(storedValue);
+        } catch (error) {
+          stateRecord[key as string] = storedValue;
+        }
+      }
     }
   }
 
   setField<K extends keyof Config>(key: K, value: Config[K]) {
     this.state[key] = value;
-    localStorage.setItem(key, value);
+    localStorage.setItem(key, JSON.stringify(value));
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure mediapipe assets are copied before starting or building so the bundle can resolve the web graph runner
- add a reusable post helper that appends API keys and expose the generation/text-to-speech options through the shared config
- tighten type usage in language model, text-to-speech, and chat components to satisfy the TypeScript build

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d77ded91008328b1a55adeed5dd840